### PR TITLE
Малютин Данила, CSC

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,7 +5,7 @@
 #include <sstream>
 #include <iostream>
 #include <stdexcept>
-
+#include <type_traits>
 
 template <typename T>
 std::string to_string(T value)
@@ -29,6 +29,27 @@ void reportError(cl_int err, const std::string &filename, int line)
 
 #define OCL_SAFE_CALL(expr) reportError(expr, __FILE__, __LINE__)
 
+template<typename T>
+typename std::enable_if<!std::is_array<T>::value, T>::type
+getDeviceInfo(cl_device_id device, cl_device_info info)
+{
+    size_t deviceInfoSize = sizeof(T);
+    T deviceInfo;
+    OCL_SAFE_CALL(clGetDeviceInfo(device, info, deviceInfoSize, &deviceInfo, nullptr));
+    return deviceInfo;
+}
+
+template<typename T, 
+    typename R = 
+        typename std::enable_if<std::is_array<T>::value, std::vector<typename std::remove_extent<T>::type>>::type>
+R getDeviceInfo(cl_device_id device, cl_device_info info)
+{
+    size_t deviceInfoSize = 0;
+    OCL_SAFE_CALL(clGetDeviceInfo(device, info, 0, nullptr, &deviceInfoSize));
+    R deviceInfo(deviceInfoSize);
+    OCL_SAFE_CALL(clGetDeviceInfo(device, info, deviceInfoSize, deviceInfo.data(), nullptr));
+    return deviceInfo;
+}
 
 int main()
 {
@@ -48,7 +69,7 @@ int main()
     std::vector<cl_platform_id> platforms(platformsCount);
     OCL_SAFE_CALL(clGetPlatformIDs(platformsCount, platforms.data(), nullptr));
 
-    for (int platformIndex = 0; platformIndex < platformsCount; ++platformIndex) {
+    for (unsigned platformIndex = 0; platformIndex < platformsCount; ++platformIndex) {
         std::cout << "Platform #" << (platformIndex + 1) << "/" << platformsCount << std::endl;
         cl_platform_id platform = platforms[platformIndex];
 
@@ -67,27 +88,57 @@ int main()
         // Затем откройте документацию по clGetPlatformInfo и в секции Errors найдите ошибку, с которой столкнулись
         // в документации подробно объясняется, какой ситуации соответствует данная ошибка, и это позволит проверив код понять чем же вызвана данная ошибка (не корректным аргументом param_name)
         // Обратите внимание что в этом же libs/clew/CL/cl.h файле указаны всевоможные defines такие как CL_DEVICE_TYPE_GPU и т.п.
+        try 
+        {
+            OCL_SAFE_CALL(clGetPlatformInfo(platform, 42, 0, nullptr, nullptr));
+        }
+        catch (const std::runtime_error &e) 
+        {
+            std::cout << "Using 42 instead of CL_PLATFORM_NAME causes: " << e.what() << std::endl;
+        }
 
         // TODO 1.2
         // Аналогично тому как был запрошен список идентификаторов всех платформ - так и с названием платформы, теперь, когда известна длина названия - его можно запросить:
-        std::vector<unsigned char> platformName(platformNameSize, 0);
-        // clGetPlatformInfo(...);
+        std::vector<char> platformName(platformNameSize, 0);
+        OCL_SAFE_CALL(clGetPlatformInfo(platform, CL_PLATFORM_NAME, platformNameSize, platformName.data(), nullptr));
         std::cout << "    Platform name: " << platformName.data() << std::endl;
 
         // TODO 1.3
         // Запросите и напечатайте так же в консоль вендора данной платформы
+        size_t platformVendorSize = 0;
+        OCL_SAFE_CALL(clGetPlatformInfo(platform, CL_PLATFORM_VENDOR, 0, nullptr, &platformVendorSize));
+        std::vector<char> platformVendor(platformVendorSize, 0);
+        OCL_SAFE_CALL(clGetPlatformInfo(platform, CL_PLATFORM_VENDOR, platformVendorSize, platformVendor.data(), nullptr));
+        std::cout << "    Platform vendor: " << platformVendor.data() << std::endl;
 
         // TODO 2.1
         // Запросите число доступных устройств данной платформы (аналогично тому как это было сделано для запроса числа доступных платформ - см. секцию "OpenCL Runtime" -> "Query Devices")
         cl_uint devicesCount = 0;
+        OCL_SAFE_CALL(clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 0, nullptr, &devicesCount));
+        std::cout << "    Number of OpenCL platform devices: " << platformsCount << std::endl;
 
-        for (int deviceIndex = 0; deviceIndex < devicesCount; ++deviceIndex) {
+        std::vector<cl_device_id> devices(devicesCount);
+        OCL_SAFE_CALL(clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, devicesCount, devices.data(), nullptr));
+        for (unsigned deviceIndex = 0; deviceIndex < devicesCount; ++deviceIndex) {
             // TODO 2.2
             // Запросите и напечатайте в консоль:
             // - Название устройства
             // - Тип устройства (видеокарта/процессор/что-то странное)
             // - Размер памяти устройства в мегабайтах
             // - Еще пару или более свойств устройства, которые вам покажутся наиболее интересными
+            auto device = devices[deviceIndex];
+            
+            auto name = getDeviceInfo<char[]>(device, CL_DEVICE_NAME);
+            std::cout << "        OpenCL device name: " << name.data() << std::endl;
+            auto mem_size = getDeviceInfo<cl_ulong>(device, CL_DEVICE_GLOBAL_MEM_SIZE);
+            std::cout << "        OpenCL device memory size: " << mem_size / (1024 * 1024) << " (MB)" << std::endl;
+            
+            auto mem_cache_size = getDeviceInfo<cl_ulong>(device, CL_DEVICE_GLOBAL_MEM_CACHE_SIZE);
+            std::cout << "        OpenCL device memory cache size: " << mem_cache_size / (1024 * 1024) << " (MB)" << std::endl;
+            auto extensions = getDeviceInfo<char[]>(device, CL_DEVICE_EXTENSIONS);
+            std::cout << "        OpenCL device supported extensions: " << extensions.data() << std::endl;
+            auto highest_opencl = getDeviceInfo<char[]>(device, CL_DEVICE_OPENCL_C_VERSION);
+            std::cout << "        OpenCL device highest supported OpenCL: " << highest_opencl.data() << std::endl;
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -134,7 +134,7 @@ int main()
             std::cout << "        OpenCL device memory size: " << mem_size / (1024 * 1024) << " (MB)" << std::endl;
             
             auto mem_cache_size = getDeviceInfo<cl_ulong>(device, CL_DEVICE_GLOBAL_MEM_CACHE_SIZE);
-            std::cout << "        OpenCL device memory cache size: " << mem_cache_size / (1024 * 1024) << " (MB)" << std::endl;
+            std::cout << "        OpenCL device memory cache size: " << mem_cache_size / 1024 << " (KB)" << std::endl;
             auto extensions = getDeviceInfo<char[]>(device, CL_DEVICE_EXTENSIONS);
             std::cout << "        OpenCL device supported extensions: " << extensions.data() << std::endl;
             auto highest_opencl = getDeviceInfo<char[]>(device, CL_DEVICE_OPENCL_C_VERSION);


### PR DESCRIPTION
Вывод на ноуте:
```
Number of OpenCL platforms: 2
Platform #1/2
Using 42 instead of CL_PLATFORM_NAME causes: OpenCL error code -30 encountered at C:\Users\flash_000\Desktop\CSC\GPGPU\Task0EnumDevices\src\main.cpp:93
    Platform name: Intel(R) OpenCL
    Platform vendor: Intel(R) Corporation
    Number of OpenCL platform devices: 2
        OpenCL device name: Intel(R) HD Graphics 4400
        OpenCL device memory size: 1629 (MB)
        OpenCL device memory cache size: 256 (KB)
        OpenCL device supported extensions: cl_intel_accelerator cl_intel_advanced_motion_estimation cl_intel_ctz cl_intel_d3d11_nv12_media_sharing cl_intel_dx9_media_sharing cl_intel_motion_estimation cl_intel_simultaneous_sharing cl_intel_subgroups cl_khr_3d_image_writes cl_khr_byte_addressable_store cl_khr_d3d10_sharing cl_khr_d3d11_sharing cl_khr_depth_images cl_khr_dx9_media_sharing cl_khr_gl_depth_images cl_khr_gl_event cl_khr_gl_msaa_sharing cl_khr_global_int32_base_atomics cl_khr_global_int32_extended_atomics cl_khr_gl_sharing cl_khr_icd cl_khr_image2d_from_buffer cl_khr_local_int32_base_atomics cl_khr_local_int32_extended_atomics cl_khr_spir
        OpenCL device highest supported OpenCL: OpenCL C 1.2
        OpenCL device name: Intel(R) Core(TM) i5-4210U CPU @ 1.70GHz
        OpenCL device memory size: 6067 (MB)
        OpenCL device memory cache size: 256 (KB)
        OpenCL device supported extensions: cl_khr_icd cl_khr_global_int32_base_atomics cl_khr_global_int32_extended_atomics cl_khr_local_int32_base_atomics cl_khr_local_int32_extended_atomics cl_khr_byte_addressable_store cl_khr_depth_images cl_khr_3d_image_writes cl_intel_exec_by_local_thread cl_khr_spir cl_khr_dx9_media_sharing cl_intel_dx9_media_sharing cl_khr_d3d11_sharing cl_khr_gl_sharing cl_khr_fp64
        OpenCL device highest supported OpenCL: OpenCL C 1.2
Platform #2/2
Using 42 instead of CL_PLATFORM_NAME causes: OpenCL error code -30 encountered at C:\Users\flash_000\Desktop\CSC\GPGPU\Task0EnumDevices\src\main.cpp:93
    Platform name: Experimental OpenCL 2.1 CPU Only Platform
    Platform vendor: Intel(R) Corporation
    Number of OpenCL platform devices: 2
        OpenCL device name: Intel(R) Core(TM) i5-4210U CPU @ 1.70GHz
        OpenCL device memory size: 6067 (MB)
        OpenCL device memory cache size: 256 (KB)
        OpenCL device supported extensions: cl_khr_icd cl_khr_global_int32_base_atomics cl_khr_global_int32_extended_atomics cl_khr_local_int32_base_atomics cl_khr_local_int32_extended_atomics cl_khr_byte_addressable_store cl_khr_depth_images cl_khr_3d_image_writes cl_intel_exec_by_local_thread cl_khr_spir cl_khr_dx9_media_sharing cl_intel_dx9_media_sharing cl_khr_d3d11_sharing cl_khr_gl_sharing cl_khr_fp64 cl_khr_image2d_from_buffer
        OpenCL device highest supported OpenCL: OpenCL C 2.0
```
На обычном ПК:
```
Number of OpenCL platforms: 2
Platform #1/2
Using 42 instead of CL_PLATFORM_NAME causes: OpenCL error code -30 encountered at F:\GitHub\Task0EnumDevices\src\main.cpp:93
    Platform name: Intel(R) OpenCL
    Platform vendor: Intel(R) Corporation
    Number of OpenCL platform devices: 2
        OpenCL device name: Intel(R) HD Graphics 4600
        OpenCL device memory size: 1629 (MB)
        OpenCL device memory cache size: 256 (KB)
        OpenCL device supported extensions: cl_intel_accelerator cl_intel_advanced_motion_estimation cl_intel_ctz cl_intel_d3d11_nv12_media_sharing cl_intel_dx9_media_sharing cl_intel_motion_estimation cl_intel_simultaneous_sharing cl_intel_subgroups cl_khr_3d_image_writes cl_khr_byte_addressable_store cl_khr_d3d10_sharing cl_khr_d3d11_sharing cl_khr_depth_images cl_khr_dx9_media_sharing cl_khr_gl_depth_images cl_khr_gl_event cl_khr_gl_msaa_sharing cl_khr_global_int32_base_atomics cl_khr_global_int32_extended_atomics cl_khr_gl_sharing cl_khr_icd cl_khr_image2d_from_buffer cl_khr_local_int32_base_atomics cl_khr_local_int32_extended_atomics cl_khr_spir
        OpenCL device highest supported OpenCL: OpenCL C 1.2
Platform #2/2
Using 42 instead of CL_PLATFORM_NAME causes: OpenCL error code -30 encountered at F:\GitHub\Task0EnumDevices\src\main.cpp:93
    Platform name: AMD Accelerated Parallel Processing
    Platform vendor: Advanced Micro Devices, Inc.
    Number of OpenCL platform devices: 2
        OpenCL device name: Hawaii
        OpenCL device memory size: 4096 (MB)
        OpenCL device memory cache size: 16 (KB)
        OpenCL device supported extensions: cl_khr_fp64 cl_amd_fp64 cl_khr_global_int32_base_atomics cl_khr_global_int32_extended_atomics cl_khr_local_int32_base_atomics cl_khr_local_int32_extended_atomics cl_khr_int64_base_atomics cl_khr_int64_extended_atomics cl_khr_3d_image_writes cl_khr_byte_addressable_store cl_khr_gl_sharing cl_khr_gl_depth_images cl_amd_device_attribute_query cl_amd_vec3 cl_amd_printf cl_amd_media_ops cl_amd_media_ops2 cl_amd_popcnt cl_khr_d3d10_sharing cl_khr_d3d11_sharing cl_khr_dx9_media_sharing cl_khr_image2d_from_buffer cl_khr_spir cl_khr_subgroups cl_khr_gl_event cl_khr_depth_images cl_khr_mipmap_image cl_khr_mipmap_image_writes cl_amd_liquid_flash cl_amd_planar_yuv
        OpenCL device highest supported OpenCL: OpenCL C 2.0
```